### PR TITLE
Default b:max_textwidth to -1

### DIFF
--- a/autoload/pencil.vim
+++ b/autoload/pencil.vim
@@ -70,6 +70,9 @@ function! pencil#init(...) abort
   if !exists('b:wrap_mode')
     let b:wrap_mode = s:WRAP_MODE_OFF
   endif
+  if !exists("b:max_textwidth")
+    let b:max_textwidth = -1
+  endif
 
   " If user explicitly requested wrap_mode thru args, go with that.
   let l:wrap_arg = get(l:args, 'wrap', 'detect')


### PR DESCRIPTION
Fixes #4

In general, I think it's good hygiene for a function to do this if its
value is expected to be set elsewhere.
