### PR TITLE
Compatibility changes for vim 7.2 in colorcolumn

### DIFF
--- a/autoload/pencil.vim
+++ b/autoload/pencil.vim
@@ -243,7 +243,7 @@ fun! pencil#init(...) abort
       setl breakat-=@         " avoid breaking at email addresses
     en
 
-    if has('syntax')
+    if exists('&colorcolumn')
       setl colorcolumn=0      " doesn't align as expected
     en
   el
@@ -255,7 +255,7 @@ fun! pencil#init(...) abort
       setl breakat<
     en
 
-    if has('syntax')
+    if exists('&colorcolumn')
       setl colorcolumn<
     en
   en


### PR DESCRIPTION
When you have a vim 7.2 installation, pencil throws an error. Its more precise to check if a certiain feature is available on the system.

The error looks like:

![screenshot 2016-06-09 11 41 02](https://cloud.githubusercontent.com/assets/203902/15926424/3b30dcb0-2e3c-11e6-98a0-3f149923bd84.png)

To fix this, i changed only 2 if conditions. 