### PR TITLE
Add vim-pandoc support

### DIFF
--- a/plugin/pencil.vim
+++ b/plugin/pencil.vim
@@ -111,6 +111,16 @@ if !exists('g:pencil#autoformat_config')
         \       'txtCode',
         \     ],
         \   },
+        \   'pandoc': {
+        \     'black': [
+        \       '^pandoc.*Code.*',
+        \       'pandocHTML',
+        \       'pandocLaTeXMathBlock',
+        \       '^pandoc.*List.*',
+        \       '^pandoc.*Table.*',
+        \       'pandocYAMLHeader',
+        \     ],
+        \   }
         \ }
 en
 if !exists('g:pencil#autoformat_aliases')


### PR DESCRIPTION
If you put a lot of code in your Markdown, [`vim-pandoc-syntax`](https://github.com/vim-pandoc/vim-pandoc-syntax) is awesome because it does syntax highlighting of the embedded code.

This PR adds to the `g:pencil#autoformat_config` so that `vim-pencil` can be used with `vim-pandoc`.