### PR TITLE
Added instructions for Vim's own built in package manager (c.2016 in Vim 8.0+)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # vim-pencil
 
+[![Vint](https://github.com/reedes/vim-pencil/workflows/Vint/badge.svg)](https://github.com/reedes/vim-pencil/actions?workflow=Vint)
+
 > Rethinking Vim as a tool for writers
 
 <br/>
@@ -91,9 +93,40 @@ tutorials available._
 [nbn]: https://github.com/Shougo/neobundle.vim
 [pth]: https://github.com/tpope/vim-pathogen
 
-#### Vundle
+#### Vim's own package manager
 
-Add to your `.vimrc` and save:
+If you haven't used Vim's built in package manager yet you need to
+create the directory in which to install packages.
+
+```bash
+mkdir -p ~/.vim/pack/plugins/start
+```
+
+You can then clone this repo to that directory with
+
+```bash
+git clone git@github.com:reedes/vim-pencil.git ~/.vim/pack/plugins/start
+```
+
+To make this easier add the following to your .bashrc
+
+```bash
+#Vim plugins
+export VIMPLUGINS=~/.vim/pack/plugins/start 
+viminstallplugin() {
+    pushd $VIMPLUGINS
+    git clone $*  
+    popd
+}
+```
+
+Run source ~/.bashrc and then you will have an environment variable and a
+bash function defined. You may now install plugins by simply running
+viminstallplugin <git repo> eg:
+
+```bash
+viminstallplugin https://github.com/reedes/vim-pencil 
+```
 
 ```vim
 Plugin 'reedes/vim-pencil'
@@ -692,6 +725,7 @@ If you find the _pencil_ plugin useful, check out these others by [@reedes][re]:
 * [vim-thematic][th] - modify Vim’s appearance to suit your task and environment
 * [vim-wheel][wh] - screen-anchored cursor movement for Vim
 * [vim-wordy][wo] - uncovering usage problems in writing
+* [vim-wordchipper][wc] - power tool for shredding text in Insert mode
 
 Unimpressed by _pencil_? [vim-pandoc][vp] offers prose-oriented features
 with its own Markdown variant.
@@ -709,6 +743,7 @@ with its own Markdown variant.
 [vw]: http://therandymon.com/woodnotes/vim-for-writers/vimforwriters.html
 [wh]: http://github.com/reedes/vim-wheel
 [wo]: http://github.com/reedes/vim-wordy
+[wc]: http://github.com/reedes/vim-wordchipper
 [vp]: http://github.com/vim-pandoc/vim-pandoc
 
 # Future development


### PR DESCRIPTION
Vim has a built in package manager that some prefer to use (and a lot of people are unaware of)

This documentation change to the README file adds instructions on how to install the package using the built in package manager and also describes a quick addition to the user's .bashrc file to make this and other package installations easier 